### PR TITLE
Support pattern directives in `define-qi-syntax-rule`

### DIFF
--- a/qi-lib/macro.rkt
+++ b/qi-lib/macro.rkt
@@ -92,10 +92,12 @@
 
 (define-syntax define-qi-syntax-rule
   (syntax-parser
-    [(_ (name . pat) template)
+    [(_ (name . pat) dirs ... tmpl)
      #'(define-dsl-syntax name qi-macro
          (syntax-parser
-           [(_ . pat) #'template]))]))
+           [(_ . pat)
+            dirs ...
+            #'tmpl]))]))
 
 (define-syntax define-qi-syntax-parser
   (syntax-parser

--- a/qi-test/tests/macro.rkt
+++ b/qi-test/tests/macro.rkt
@@ -12,11 +12,31 @@
          syntax/macro-testing
          "private/util.rkt")
 
-(define-qi-syntax-rule (square flo:expr)
+(define-qi-syntax-rule (square flo)
   (feedback 2 flo))
 
 (define-qi-syntax-rule (pare car-flo cdr-flo)
   (group 1 car-flo cdr-flo))
+
+(define-qi-syntax-rule (ensure-number n:number)
+  (gen n))
+
+(define-qi-syntax-rule (repeat-3 f)
+  #:with g #'(~> f f f)
+  g)
+
+(define-qi-syntax-parser repeat
+  [(_ 2 f)
+   #:with g #'(~> f f)
+   #'g]
+  [(_ 3 f)
+   #:with g #'(~> f f f)
+   #'g])
+
+(define-qi-syntax-parser calc
+  #:datum-literals (plus minus)
+  [(_ plus) #'+]
+  [(_ minus) #'-])
 
 (define-qi-syntax-parser cube
   [(_ flo) #'(feedback 3 flo)])
@@ -54,6 +74,11 @@
     "base"
     (check-equal? ((☯ (square sqr)) 2) 16)
     (check-equal? ((☯ (~> (pare sqr +) ▽)) 3 6 9) (list 9 15))
+    (check-equal? ((☯ (ensure-number 5))) 5 "single-clause macros can use syntax classes")
+    (check-equal? ((☯ (repeat-3 add1)) 5) 8 "single-clause macros can include pattern directives")
+    (check-equal? ((☯ (repeat 2 add1)) 5) 7 "multi-clause macros can include pattern directives")
+    (check-equal? ((☯ (calc plus)) 5 3) 8 "multi-clause macros can include parse options")
+    (check-equal? ((☯ (calc minus)) 5 3) 2 "multi-clause macros can include parse options")
     (check-equal? ((☯ (cube sqr)) 2) 256)
     (check-equal? ((☯ (fanout 5)) 2) 'hello "extensions can override built-in forms")
     (check-equal? ((☯ kazam) 2) 'hello "extensions can add identifier macros"))


### PR DESCRIPTION
### Summary of Changes

Racket's `define-syntax-parse-rule` supports `#:with` and other pattern directives, whereas Qi's analogous `define-qi-syntax-rule` did not. This adds the support, to bring the interface to parity with Racket.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
