### PR TITLE
Track design documents and POCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage
 # docs output
 *.html
 *.css
+!design/assets/css/style.css
 *.js
 MathJax
 katex

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ build:
 	raco make -l qi -v
 
 design:
+	scribble ++style design/assets/css/style.css --html --dest design/language-composition/output --dest-name index design/language-composition/language-composition.scrbl
 	scribble ++style design/assets/css/style.css --html --dest design/pacman-streams/output --dest-name index design/pacman-streams/pacman.scrbl
 
 # Primarily for day-to-day dev.

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ remove-sdk:
 build:
 	raco make -l qi -v
 
+design:
+	scribble ++style design/assets/css/style.css --html --dest design/pacman-streams/output --dest-name index design/pacman-streams/pacman.scrbl
+
 # Primarily for day-to-day dev.
 # Build docs (if any).
 build-docs:
@@ -257,4 +260,4 @@ performance-report:
 performance-regression-report:
 	@racket $(PACKAGE-NAME)-sdk/benchmarks/report.rkt -r $(REF)
 
-.PHONY:	help install remove build build-docs build-all clean check-deps test-all test test-flow test-on test-threading test-switch test-definitions test-macro test-util test-expander test-compiler test-probe test-with-errortrace errortrace errortrace-flow errortrace-on errortrace-threading errortrace-switch errortrace-definitions errortrace-macro errortrace-util errortrace-probe docs cover coverage-check coverage-report cover-coveralls profile new-benchmarks new-benchmarks-preview benchmark-local benchmark-loading benchmark-selected-forms benchmark-competitive benchmark-nonlocal benchmark performance-report performance-regression-report
+.PHONY:	help install remove build build-docs build-all clean check-deps design test-all test test-flow test-on test-threading test-switch test-definitions test-macro test-util test-expander test-compiler test-probe test-with-errortrace errortrace errortrace-flow errortrace-on errortrace-threading errortrace-switch errortrace-definitions errortrace-macro errortrace-util errortrace-probe docs cover coverage-check coverage-report cover-coveralls profile new-benchmarks new-benchmarks-preview benchmark-local benchmark-loading benchmark-selected-forms benchmark-competitive benchmark-nonlocal benchmark performance-report performance-regression-report

--- a/design/assets/css/style.css
+++ b/design/assets/css/style.css
@@ -1,0 +1,87 @@
+.tocsub {
+    background-color: #3e5ba9;
+    font-family: 'Candara', sans-serif;
+}
+
+.tocview {
+    background-color: #3e5ba9;
+    font-family: 'Candara', sans-serif;
+}
+
+.tocviewselflink {
+	color: #FDFBD4;
+}
+
+.tocviewtoggle {
+	color: #FDFBD4;
+}
+
+.tocviewlink {
+	color: #FDFBD4;
+}
+
+.tocset {
+    background-color: #3e5ba9;
+	border-color: #3e5ba9;
+    width: 14.5em;
+}
+
+.maincolumn {
+    margin-left: 17em;
+}
+
+.tocsubseclink {
+	color: #FDFBD4;
+}
+
+.tocsublinknumber {
+	color: #FDFBD4;
+}
+
+.RktSym {
+	color: #ED5F28;
+}
+
+.status-accepted {
+    color: #ED5F28;
+    font-style: italic;
+}
+
+.status-archived {
+    color: #8A6868;
+    font-style: italic;
+}
+
+.status-draft {
+    color: inherit;
+    font-style: italic;
+}
+
+body {
+    background-color: #FDFBD4;
+}
+
+p {
+  font-family: Constantia, "Palatino Linotype", Palatino, serif;
+  line-height: 1.25;
+}
+
+h2 {
+    font-family: 'Candara', sans-serif;
+}
+
+h3 {
+    font-family: 'Candara', sans-serif;
+}
+
+h4 {
+    font-family: 'Candara', sans-serif;
+}
+
+h5 {
+    font-family: 'Candara', sans-serif;
+}
+
+.SSubSubSubSection {
+    font-family: 'Candara', sans-serif;
+}

--- a/design/language-composition/language-composition.scrbl
+++ b/design/language-composition/language-composition.scrbl
@@ -1,0 +1,393 @@
+#lang scribble/base
+
+@require[(only-in scribble/jfp abstract)
+         scribble/manual
+         scriblib/figure]
+
+@title{Language Extension Through Inheritance and Composition}
+
+@centered{@bold{@tt{Technical Specification}}}
+@centered{@bold{@tt{Status: @elem[#:style "status-archived"]{@tt{ARCHIVED}}}}}
+
+@abstract{We look at a few different ways of extending a hosted language implemented in Syntax Spec. We describe a means of extension that affords the same flexibility to hosted languages that Syntax Spec already brings to the host language, that is, holistic and sound syntactic and runtime extensibility.}
+
+@section{Background}
+
+We want the Qi compiler to implement optimizations in terms of invariants distinct from the host language. We'd also like such optimizations to be extensible to arbitrary datatypes without bundling such optimizations in the core library, and would like to be able to use such optimizations in concert. Implementing a general solution in Syntax Spec could address these issues for all hosted languages.
+
+@section{Proposal}
+
+@subsection{Introduce a @code{language} type}
+
+This type distinguishes expansion, compilation, and code generation as the distinct components of a language, providing a basis for a composable interface.
+
+@codeblock{
+  (struct language (base
+                    expander
+                    compiler
+                    codegen))
+}
+
+We can ignore the @racket[base] attribute for the moment -- we'll discuss it later when we talk about inheritance.
+
+@subsection{Defining languages}
+
+To illustrate by example, we define three languages, @racket[qi-base], containing the core Qi language, @racket[qi-list] containing the list-specific forms (e.g. @racket[map] and @racket[filter]), and @racket[qi-std] containing the values-specific forms (e.g. @racket[><] and @racket[-<]).
+
+@subsubsection{@racket[qi-base]}
+
+@codeblock{
+  (module qi-base
+    (require "expander.rkt"
+             "compiler.rkt"
+             "codegen.rkt")
+
+    (syntax-spec
+      (language qi-base
+        #:description "Qi base language"
+        floe-base
+        compile-floe-base
+        qi-base->racket)
+
+      (host-interface/language
+        (flow f:floe-base))))
+}
+
+@subsubsection{@racket[qi-list]}
+
+@codeblock{
+  (module qi-list
+    (require "expander.rkt"
+             "compiler.rkt"
+             qi/base)
+
+    (syntax-spec
+      (language qi-list
+        #:description "Qi list language"
+        #:base qi-base
+        floe-list
+        compile-floe-list)
+
+      (host-interface/language
+        (flow f:floe-list))))
+}
+
+@subsubsection{@racket[qi-std]}
+
+@codeblock{
+  (module qi-std
+    (require "expander.rkt"
+             "compiler.rkt"
+             qi/base)
+
+    (syntax-spec
+      (language qi-std
+        #:description "Qi standard language"
+        #:base qi-base
+        floe-std
+        compile-floe-std)
+
+      (host-interface/language
+        (flow f:floe-std))))
+}
+
+Each of these languages declares its own expansion, compilation (including optimizations) and code generation. In the case of @racket[qi-base], the definition provides explicit implementations for all of these, while the other two languages indicate code generation implicitly by use of the @racket[#:base] argument. We will refer to this code block and discuss @racket[#:base] more soon, when we talk about inheritance. Other aspects like the expanders, via nonterminal (e.g. @racket[floe-list]) specifications, are defined in ways that are already supported in Syntax Spec as of this writing.
+
+@subsection{Composing languages}
+
+We compose the Qi language from these languages and provide it to the user in a way that matches the existing interface.
+
+@codeblock{
+  (module qi
+    (provide (for-space qi (all-defined-out))
+             flow)
+    (require qi/base qi/list qi/std)
+
+    (syntax-spec
+
+      (language qi
+        #:description "Qi language"
+        #:compose (qi-list
+                   qi-std)
+        #:base qi-base
+        #:as floe)
+
+      (host-interface/language
+        (flow f:floe))))
+}
+
+At the same time, we also provide @racket[qi-list], @racket[qi-std] and @racket[qi-base] directly, so that the user could compose it differently using the same Syntax Spec interface.
+
+@codeblock{
+  (module qi-minimal
+    (provide (for-space qi (all-defined-out))
+             flow)
+    (require qi/base qi/std)
+
+    (syntax-spec
+      (language qi-minimal
+        #:description "Qi minimal language"
+        #:compose (qi-std)
+        #:base qi-base
+        #:as floe)
+
+      (host-interface/language
+        (flow f:floe))))
+
+  (module my-application
+    (require "qi-minimal.rkt"))
+}
+
+In this case, leaving out @racket[qi-list] if they aren't using lists in their application. As there is only one language in the composition here, @racket[qi-minimal] is equivalent to @racket[qi-std]. We expect @racket[(require qi)] to already be fairly minimal, so the flexibility to compose languages becomes more useful with an increasing number of community optimizations for bespoke data types, so that one might do:
+
+@codeblock{
+  (module qi-datascience
+    (provide (for-space qi (all-defined-out)))
+    (require qi/base qi/std qi/hash qi/df)
+
+    (syntax-spec
+
+      (language qi-datascience
+        #:description "Qi data science language"
+        #:compose (qi-dataframe
+                   qi-hash
+                   qi-std)
+        #:base qi-base
+        #:as floe)
+
+      (host-interface/language
+        (flow f:floe))))
+
+  (module my-application
+    (require "qi-datascience.rkt"))
+}
+
+This allows users (or library authors) to compose the appropriate languages for specific domains while keeping the language as lean as possible (e.g. without pulling in every possible optimization).
+
+Also note that the @racket[floe] nonterminal indicated in the host interface form in each of these cases indicates subexpressions by @emph{language} and entails compilation. We do not explicitly invoke compilation here as we do in the @racket[host-interface/expression] form currently used in the Qi codebase. This is because we will be leaving it to Syntax Spec to compile the syntax in the appropriate manner, which may vary depending on how the language is composed, as we will see.
+
+@subsection{Nature of Composition}
+
+Each language in the composition must include all of the Qi base language. Otherwise, they wouldn't recognize nested syntax that could be optimized. For example:
+
+@codeblock{
+  (~> (filter odd?) (map sqr))
+}
+
+Here, @racket[filter] and @racket[map] are forms of the @racket[qi-list] language, but @racket[~>] is a form of the @racket[qi-base] language. If the latter were not also part of @racket[qi-list], then compilation at that stage would consider this to be unknown syntax and refrain from traversing it.
+
+@subsubsection{Language Inheritance}
+
+In order to include the Qi base language in each of the various dialects, it would be necessary to provide some form of inheritance so that all of the languages share the same core bindings literally, and to avoid duplicate definitions.
+
+@codeblock{
+  (syntax-spec
+    (nonterminal floe-list
+      #:description "a list flow expression"
+      #:binding-space qi
+
+      (map f:floe-list)
+      (filter f:floe-list)
+      (foldl op:floe-list init:racket-expr)
+      (foldr op:floe-list init:racket-expr)
+      (range e:racket-expr ...+)))
+}
+
+Here, the syntax specification doesn't include any base language forms (such as @racket[esc]) as we have already declared the @racket[qi-list] language to "extend" @racket[qi-base] via:
+
+@codeblock{
+  (syntax-spec
+    (language qi-list
+      #:description "Qi list language"
+      #:base qi-base
+      floe-list
+      …))
+}
+
+(as we saw above).
+
+The @racket[qi-base] expander itself is defined as:
+
+@codeblock{
+  (syntax-spec
+    (nonterminal floe-base
+      #:description "a base flow expression"
+      #:binding-space qi
+
+      _
+      (thread f:floe-base ...)
+      (esc e:racket-expr)
+      (~> f:id
+          #:with spaced-f ((make-interned-syntax-introducer 'qi) #'f)
+          #'(esc spaced-f))))
+}
+
+The nonterminal specifications are composed by concatenating them (which we'll designate by the notation @litchar{||}): @racket[floe-list]@litchar{||}@racket[floe-base]. The concatenation respects ordinary precedence in pattern matching, so that @racket[floe-list] expansions take precedence over @racket[floe-base].
+
+@subsubsub*section{Extending Scoping Rules?}
+
+The scoping rules are part of the base language and cannot be overridden by languages that inherit from it. This is already the case in languages defined with Syntax Spec -- only core forms can specify binding rules, not macros. If the ability to specify binding rules is extended to macros, then the same mechanism may suggest ways to extend it to overlying languages.
+
+@subsubsection{Order of Compilation}
+
+As for the compilers, we would like base language compilation to occur at the very end, if we happen to compose this language with other languages. Otherwise, we might prematurely optimize a base language expression that might have benefited from other nonlocal optimizations made possible by the compilation of subsequent languages (to the base language). Thus, the composition interface (which we'll talk about next) needs to be aware of base language compilation and code generation as distinct from compilation of the languages in the composition.
+
+Compilation of language extensions produces base language code. For instance, compilation of @racket[qi-list] code produces @racket[qi-base] code.
+
+@subsubsection{Mechanism of Composition}
+
+The @racket[#:compose] syntax (just an example) above translates into an underlying language composition operation. This operation suspends judgement of invalid syntax until the very end of compilation. If a language in the composition rejects the input syntax (implying it also wasn't in the base language), then it is still passed on, verbatim, to the next language in the composition. Base language forms are likewise left uncompiled (but expanded) in providing the syntax to the next language.
+
+When all the languages in the composition have processed the input syntax, it is forwarded to the base language compiler, followed by code generation to Racket.
+
+The pseudocode below illustrates this composition of languages:
+
+@codeblock{
+  (struct language
+    (expander
+     compiler
+     codegen))
+
+  (define identity-lang
+    (language (void)
+              identity
+              identity
+              identity))
+
+  (define (lang-comp2~> a b)
+    (let ([a:expand (language-expander a)]
+          [a:compile (language-compiler a)]
+          [b:expand (language-expander b)]
+          [b:compile (language-compiler b)])
+      (λ (stx)
+        (b:compile
+         (b:expand
+          (a:compile
+           (a:expand stx)))))))
+
+  (define (language-compose~> . ls)
+    (λ (stx)
+      (if (empty? ls)
+          identity-lang
+          (let* ([base (language-base
+                        (car ls))] ; get the base language for the composition
+                 [base-compile (language-compiler base)]
+                 [base-codegen (language-codegen base)])
+            (base-codegen
+             (base-compile
+              (let ([overlying-composed-lang (foldr lang-comp2~> identity-lang ls)])
+                (overlying-composed-lang stx))))))))
+}
+
+@subsubsection{Multiple Inheritance?}
+
+A language can only have one base language, and languages can only be composed when they share a common base language. Given any two languages @racket[B] and @racket[C], it is not possible for a language @racket[D] to be based on both @racket[B] and @racket[C]. Instead, what could happen is if @racket[B] and @racket[C] are both based on @racket[A] then @racket[D] could be based on the composed language @code{(B, C)}. This is a valid composition since @racket[B] and @racket[C] share a base language. In this case, @racket[D] would compile to @code{(B, C)} which compiles to @racket[A]. As @code{(B, C)} and @code{(C, B)} are explicit and distinct compositions implying different precedence in the handling of input syntax, there is no ambiguity of the kind that typically characterizes "diamond inheritance" in object-oriented programming contexts.
+
+@section{Outlook}
+
+@subsection{Technical Value}
+
+@itemlist[#:style 'ordered
+  @item{Safe interaction between the host and the DSL.}
+  @item{Interaction between compiler passes is well-modeled and scalable.}
+  @item{Compiling to different backends is straightforward.}
+]
+
+Let's look at each of these in more detail.
+
+@subsubsection{Safe Interaction With the Host}
+
+Compiler optimizations we perform are in terms of actual hosted DSL core forms, not matching and optimizing arbitrary patterns on host language syntax as we do today. Thus, there is no possibility of inappropriate interpretation of host language syntax or violation of host language invariants.
+
+This also means that the optimizations are transparent and IDE-friendly, as they are performed via introspectable and documentable bindings. If there is any unexpected behavior, the user would be able to introspect the bindings and discover whether they are Qi bindings or Racket bindings, and also be able to find documentation for them that would elaborate on any optimizations performed.
+
+This example -- representing Qi's production behavior today -- illustrates the inadvisability of optimizing host-language syntax:
+
+@codeblock{
+  #lang racket
+
+  (require qi
+           qi/list)
+
+  (define (filter f lst)
+    'hello)
+
+  (~>> () (range 1000) (filter odd?) (map sqr) (foldl + 0)) ;=> 166666500 (!)
+}
+
+The semantics are obviously unexpected, yet introspecting the @racket[filter] binding in an IDE identifies it as the locally defined function. This is because the compiler does datum matching for optimizations (by intended design) but on host language syntax (not by intended design), and so Syntax Spec does not have an opportunity to validate that input syntax is appropriate for those optimizations.
+
+This extreme example illustrates what is already the case even in what we might nominally consider "expected" behavior, where an expression like @racket[(~>> (filter odd?) (map sqr))], ostensibly a partial application of host language functions to list inputs, exhibits a different order of effects from these functions by virtue of deforestation. Here, too, introspecting the @racket[filter] binding identifies it as the standard binding in @racket[racket/list], yet, as we have seen, exhibiting different semantics that are not documented there, and which are not discoverable in the IDE.
+
+@subsubsection{Scalable Interaction Between Compiler Passes}
+
+Interaction between passes is not left to fragile convention but rather is well-modeled as explicit composition. There is no ambiguity about the handling of input syntax by composed languages. Additionally, the contract between languages is the publicly advertised core language rather than arbitrary internal representations that must be carefully synchonized. This simultaneously presents a clean interface and ensures a low maintenance burden.
+
+@subsubsection{Ease of Compiling to Different Backends}
+
+Flows may be compiled to ordinary functions, threads, futures, AWS Lambda Step Functions, or anything else, simply by using a different base language -- more specifically, a base language with a different code generation step. This allows different languages to have the same surface syntax with dramatically different -- and yet isomorphic -- semantics, while maximizing code reuse and maintainability.
+
+@subsection{Social Value}
+
+@itemlist[#:style 'unordered
+  @item{Significantly broadens the applicability and scope for adoption of Syntax Spec.}
+  @item{An elegant interface encourages data structure authors to contribute compiler extensions as libraries, for Qi and for Racket, in a way that is theoretically sound.}
+  @item{A pleasant development experience encourages community participation. It avoids tedious social overhead in favor of fun social interactions.}
+  @item{This surely opens up many new possibilities that are likely to get the community excited.}
+  @item{More familiarity with Syntax Spec internals through a community project.}
+  @item{It makes the Racket ecosystem more compelling, including for industry, which could bring new opportunities.}
+]
+
+@subsection{Research Value}
+
+@itemlist[#:style 'unordered
+  @item{Helps to reveal and define Syntax Spec's long term interface.}
+  @item{Solving essential things now so that we have help for superficial things later.}
+  @item{This theoretically sound composition of compiler extensions presents an elegant interface that is useful and perhaps novel.}
+  @item{It opens up new avenues for research down the line, and possibly invites new collaborators.}
+]
+
+@section{Other Approaches}
+
+@subsection{Hardcoded composition of passes}
+
+Define and compose individual optimization passes in the Qi core.
+
+@subsubsection[#:tag "hardcoded assessment"]{Assessment}
+
+This is the simplest and the original approach. It achieves optimization in a standard architecture of passes, and also ensures a predictable semantics for the language without the possibility of ad hoc overrides. But it isn't extensible, and thus would require bespoke optimizations to be added in the Qi core, bloating the language.
+
+In contrast, the proposed approach allows optimizations to be written in the Qi core or by third parties using the same interface, for maximum flexibility. It also retains the property of predictable semantics that can be overridden only through standard means such as shadowing of bindings.
+
+@subsection{Composition via Racket}
+
+Define a compiler pass as a new language (say, @racket[qi-list]) that explicitly matches all standard Qi syntax and wraps them in the usual @racket[flow] host interface macro during compilation, thus delegating standard forms to the standard Qi language in addition to layering on optimizations.
+
+@subsubsection[#:tag "racket composition assessment"]{Assessment}
+
+This keeps internal implementation details contained within languages and presents a clean contract between languages. It also extends language semantics by layering optimizations on top of an existing language rather than mutating it, thus presenting predictable semantics. But as the composition is essentially hardcoded, a @racket[qi-list] language would not compose with a @racket[qi-dataframe] language, and we would need to pick just one, or manually write a @racket[qi-df-list] language that includes both sets of optimizations, duplicating them and requiring independent maintenance. Additionally, if an optimization compiles to a use of the core language which could ordinarily be further optimized when considered in the surrounding context, such optimization would not occur as the use of each of the higher level languages would be wrapped with @racket[(esc ...)], and the compilation of the containing core language expression would not traverse these expressions to detect this would-be optimization.
+
+In contrast, the proposal ensures that optimizations are composable both at the level of the overlying languages as well as at the base language level. By leveraging "inheritance," it also avoids any code duplication.
+
+@subsection{Mutable Compile-time Registry}
+
+Define passes in modules that could be part of the Qi core package or maintained independently. Register these passes as a require-time side-effect.
+
+@subsubsection{Assessment}
+
+This is the current approach and it was adopted for expediency in order to decouple short term optimization work (i.e. deforestation) from Qi core development. Yet, as a long term solution, it suffers from drawbacks:
+
+@itemlist[#:style 'unordered
+  @item{The semantics of the language are not static but may be overridden through mutation via a @racket[require] side effect. In contrast, the proposal supports overriding semantics only through the standard means of shadowing.}
+  @item{Extension requires knowledge of internal intermediate representations as well as the placement of passes by other extensions. In contrast, the proposal only assumes knowledge of the public core language and does not encode any nonlocal information in the definition of optimizations.}
+  @item{Optimizing host-language syntax conflates DSL invariants with those of the host language. In contrast, the proposal cleanly differentiates these so that optimizations do not transgress the host language.}
+  @item{The addition of new passes in the core must take into account the entire ecosystem of optimizations, necessitating superfluous conventions. In contrast, the proposal ensures that core (and third-party) optimizations can be developed in isolation, without knowledge of other optimizations in the ecosystem.}
+  @item{The technical contract between passes is unmodeled and reduces to unnecessary and troublesome social overhead. We cannot reason formally about the ecosystem of optimizations. In contrast, the proposal calls for explicit composition that defines precedence of languages, and preserves language invariants at the technical rather than social level.}
+  @item{The introduction of a new pass at any time could necessitate code changes in all downstream passes. The contract of backwards compatibility is needlessly complicated. In contrast, the proposal guarantees that passes will compose with any other passes, and in any order. The only backwards compatibility contract is on the advertised core language, which thus introduces nothing new.}
+]
+
+This approach has a low upfront cost, but in the long run it causes us to spend a lot of time thinking about artificial problems and considerations, and that could prevent us from discovering worthwhile and novel things.
+
+@section{Conclusion}
+
+The proposed composition and inheritance scheme supports sound and scalable compiler extension for hosted languages in a way that does not suffer from the drawbacks of competing approaches and opens up many interesting avenues of future exploration.

--- a/design/pacman-streams/pacman.scrbl
+++ b/design/pacman-streams/pacman.scrbl
@@ -1,0 +1,382 @@
+#lang scribble/base
+
+@require[(only-in scribble/jfp abstract)
+         scribble/manual
+         scriblib/figure]
+
+@title{Virtual Multi-valued Streams @(linebreak) or, "Pac-Man Continuations" @(linebreak)}
+
+@centered{@bold{@tt{Technical Specification}}}
+@centered{@bold{@tt{Status: @elem[#:style "status-accepted"]{@tt{ACCEPTED}}}}}
+
+@abstract{
+  A detailed description of the design of the continuation-passing multi-valued stream implementation proposed for the Qi compiler, which naturally generalizes the existing single-valued implementation while preserving its performance characteristics. The generalization is achieved by means of threading two continuations through the stream: a @emph{pending output continuation} @code{k-pending}, and a @emph{return continuation} @code{k-return}, preserving other aspects of the stream implementation. These two continuations accumulate pending output in a single stream cycle, and support returning to points which yield additional values in the same cycle, respectively. In this way, they "unroll" the static stream, which is capable of producing zero or one value per cycle, into a longer dynamic stream capable of producing any number of values per cycle.
+}
+
+@section{Background}
+
+Stream fusion is an approach to compiling functional sequence-oriented operations like @code{map}, @code{filter} and @code{foldl}. It represents the input as a stream of values rather than as a specific data structure such as a list, and then operates on these values individually through all of the stages of transformation, effectively fusing these into a single aggregate operation on each individual input value. This fusion of value-oriented operations avoids intermediate representations of the entire collection (for example, the construction of an intermediate list after @code{map}, after @code{filter}, and so on). The survey paper by Vincent St-Amour @cite{St-Amour12} explains the motivation and development of this approach.
+
+This optimization is essential in settings dealing with large datasets or realtime applications where latency is critical. Additionally, because streams operate on values directly, they are agnostic to input and output data structures, making them a good candidate for optimizing Qi flows which, too, operate on values directly.
+
+Qi currently implements this optimization, but it is restricted to list inputs and "linear" list-oriented operations, i.e., consuming and producing at most one value at each step. Qi's implementation of stream fusion employs @emph{continuation-passing style (CPS)} to take advantage of efficient compilation of this pattern in Racket/Chez, where continuing via lambdas in tail position (rather than the usual programming pattern of function invocation and use of return values) effectively compiles to GOTOs (see "LAMBDA: The Ultimate GOTO"@cite{Steele77}). In other words, CPS is very fast in Racket.
+
+@section{Guide}
+
+@secref["Overview"] summarizes the semantics of a stream. @secref["Architecture_of_the_Stream"] describes Qi's stream implementation, and the proposed modifications. @secref["A_Stream_Cycle"] describes the processing of a single value by the stream, including the dynamic of "cycles" and "epicycles." @secref["Analysis"] analyzes each component of the stream's operation in isolation. @secref["Stages_of_Processing"] describes the distinct semantics of the producer, transformer, and consumer. @secref["Reference_Code"] provides a minimal and faithful end-to-end code example.
+
+@section{Overview}
+
+A stream is a computation expressed as a series of operations on individual values. It is made up of stream segments. Any given segment is one of:
+
+@itemlist[
+  @item{Producer}
+  @item{Transformer}
+  @item{Consumer}
+]
+
+A producer generates values given some input parameters (e.g., an input list, which it destructures).
+
+A transformer considers each value and yields zero or more values (e.g., @code{map} or @code{filter}).
+
+A consumer evaluates the stream result (e.g., convert back to a list, or @code{foldl} to produce an aggregate value such as a sum).
+
+@section{Architecture of the Stream}
+
+This section describes the overall operation of the CPS stream fusion implementation. Most of it describes Qi's existing implementation already @hyperlink["https://github.com/drym-org/qi/wiki/The-Compiler#stream-fusion"]{documented in the Wiki}, but summarized below, while some of it describes the new proposal.
+
+As summarized in the previous section, a stream is made up of stream segments: a producer, followed by any number of transformers, followed by a consumer.
+
+Generally speaking, a stream segment is a @emph{closure} that accepts precisely three arguments: the continuations @code{done} (called by any segment to terminate the stream), @code{skip} (called to exclude a value from the result) and @code{yield} (called to convey a value forward to the next stream segment).
+
+Each stream segment closes over additional arguments that parametrize its behavior. These arguments include, at a minimum, the @code{previous} stream segment (also a closure) [note that in the Qi source code, we use the word "next" for this, rather than "previous," which although true in an order-isomorphic sense, we avoid here because the binding refers to the preceding rather than the next segment in the stream!].
+
+The exceptions to these rules are that @emph{consumers} don't close over any continuations (since they are the end of the stream, and are responsible for defining these three ultimate continuations), and @emph{producers} don't close over a @code{previous} segment (since they are the beginning of the stream and are responsible for processing the input).
+
+Aside from these, the other arguments that parametrize each segment are specific to the semantics of the operation being performed. For instance, @code{map} closes over, in addition to @code{previous}, a function @code{f} to apply to each value, while @code{take} closes over a number @code{n} of values to keep. In the Qi compiler, we also capture and pass source syntax objects among these closed-over arguments, to aid error reporting.
+
+The stream's architecture as a nest of closures entails two distinct times of interest: the time when the stream is @emph{constructed} (when it evaluates to a closure), and the time when the stream is @emph{applied} to input arguments (e.g., a list), when it evaluates to the computed output of the stream (e.g., a list).
+
+At construction time, each stream segment, in turn, binds the @emph{previous} stream segment's @code{done}, @code{skip}, and @code{yield} continuations by wrapping the ones it receives from the @emph{next} segment (which are ultimately defined in the consumer) with its own semantics.
+
+In the current implementation in the compiler, the @code{done} continuation expects no arguments, the @code{skip} continuation expects one argument — the @emph{next} stream state (typically short-circuiting all the way to the consumer to skip the current stream value), while the @code{yield} continuation expects two arguments — the current segment's computed output value and the next stream state.
+
+The proposal introduces two additional arguments to @code{done}, @code{skip} and @code{yield} — a @emph{pending output} continuation @code{k-pending}, and a @emph{return} continuation @code{k-return}. These are used specifically for the purpose of enabling individual segments to yield multiple times, by keeping track of pending output in each stream cycle and bookmarking points to return to to compute additional output before moving on to the next cycle. This will be described in detail below.
+
+At application time, the stream eagerly evaluates to a result.
+
+@section{A Stream Cycle}
+
+A single stream cycle is defined as the processing by the steam of a single value produced from the input state. This section describes a stream cycle.
+
+As described in the previous section, a stream is a nest of closures, with the consumer of the stream being outermost and the producer of the stream being innermost.
+
+When this closure is applied, it is therefore the consumer that receives the input state first. It applies the previous segment (a closure) to this input state, which in turn does the same, and, in this manner, this input state propagates all the way to the producer (which is innermost).
+
+The producer analyzes the state to determine whether the stream is exhausted, in which case it signals termination of the stream to the consumer. Otherwise, it produces (1) a value, and (2) a next input state.
+
+Crucially, in either of these cases, these aren't conveyed to subsequent (i.e., wrapping) stream segments as @emph{return values}, but rather via the @emph{continuations} that were received from them as arguments at construction time: either the @code{done} continuation (in the former case of stream exhaustion) or the @code{yield} continuation (in the latter case of producing a value and new state). If at any point thereon a segment (typically a transformer) decides that a value should be excluded from the result (e.g., @code{filter}), it calls the @code{skip} continuation. These continuation invocations are tail calls, that is, their return values aren't used in the calling frame, so these frames may be ignored and are in practice eliminated by the Racket/Chez compiler (tail-call elimination), and we can just follow the computation "forward" all the way through the series of stream segments to the consumer, rather than needing to unwind the stack.
+
+In the case of a yield, the produced @emph{value} will be processed by all succeeding segments in the stream in the present cycle, yielding zero or more output values or even early termination of the stream (as determined by the semantics of each stream segment), while the @emph{next stream state} will simply be conveyed unchanged all the way to the consumer, for it to use to begin the next stream cycle, in exactly the way described in the present section, that is, beginning with the application of the stream (closure) to the @emph{next} stream state conveyed from the producer.
+
+@subsection{Epicycles}
+
+With the introduction of the @code{k-pending} and @code{k-return} continuations to support multi-valued streams, instead of the consumer always invoking the stream on the next state upon receiving each new value, there may now be additional values that need to be produced in the @emph{current} cycle. In such cases, the consumer returns to bookmarked points in the stream where these additional values need to be produced, continuing forward through the stream once again from there, accumulating "pending output" each time it returns to the consumer. These recurrences within the current cycle form smaller "epicycles" which may be nested. When all return points have been fulfilled, the pending output is computed and the consumer then starts the next stream cycle, as before. The precise mechanism of these epicycles is described in the analysis below of each continuation and each stage of stream operation.
+
+@section{Analysis}
+
+@subsection{Yielding Values}
+
+Stream segments typically forward the @code{done} and @code{skip} continuations unchanged, so that these short-circuit all the way to the consumer.
+
+When a stream segment @code{yield}s a value, it must forward:
+
+@itemlist[
+  @item{A value (exactly one).}
+  @item{The remaining stream state.}
+  @item{The pending output continuation.}
+  @item{The return continuation for any pending work.}
+]
+
+Since it can yield precisely @emph{one} value (note that @code{skip} is used to yield zero values), we must find some way to yield multiple @emph{times} in the present stream cycle in order to yield multiple @emph{values} from a single stream segment. That's where the two new continuations come in.
+
+@subsection{The Pending Output Continuation, @code{k-pending}}
+
+The pending output continuation refers to a way of tracking the output computed by the stream that enables segments to yield any number of values in each stream cycle. It is defined and managed exclusively by the consumer, as this is the only point in the stream where the output may be determined.
+
+Consumers like @code{foldr} process the stream from left to right and are not tail-recursive in the driver loop. But others like @code{foldl} are tail-recursive and pass the intermediate result to the recursive call. These two cases must handle the pending output continuation differently, and the latter style affords some optimizations.
+
+@subsubsection{Non-tail-recursive Consumer}
+
+@itemlist[
+  @item{It is a @emph{thunk}.}
+  @item{It is typically a recursive call to the driver loop beginning the @emph{next} stream cycle, @code{(λ () (go vs))}.}
+  @item{The final call to it evaluates to the seed value for accumulation (for example, @code{0} for a simple consumer performing addition), @code{(λ () init)}}
+  @item{Appending to it entails calling it and then operating on the result, e.g., @code{(cons v (k-pending))}.}
+  @item{When called, it does @emph{all} of the remaining work on the entire stream.}
+]
+
+This style of consumer grows the call stack throughout the lifecycle of the stream, collapsing it at the end in producing a result (like any recursion that is not tail-recursive).
+
+@subsubsection{Tail-recursive Consumer}
+
+@itemlist[
+  @item{It is an ordinary @emph{value}.}
+  @item{It represents the intermediate result computed up to this point on the entire stream thus far, including work from previous stream cycles and any work so far on the current stream cycle.}
+  @item{It is initialized to @code{init}, a seed value specified by the consumer (for example, @code{0} for a simple consumer performing addition).}
+  @item{"Appending" to it entails directly incorporating the latest stream value on-the-fly, e.g., @code{(cons v k-pending)}.}
+  @item{When all of the pending output from the current cycle has been incorporated into this value, the driver loop then passes it as the result argument (the accumulator) in the recursive call to the next stream cycle, i.e., @code{(go vs k-pending)}.}
+]
+
+This style of consumer does not build up the call stack while processing the stream since, as we see here, the new intermediate result is computed as soon as each stream value is available. The "continuation" here is not a function but simply a value representing the result, to be used directly to "escape" at the end — a kind of degenerate continuation.
+
+@subsubsection{In Either Case}
+
+@itemlist[
+  @item{Only the consumer appends to pending output.}
+  @item{Other segments just pass it forward.}
+  @item{The producer must initialize it to @code{#false} because it cannot determine the continuation — only the consumer can.}
+]
+
+Since the (any) consumer is the only one that manipulates @code{k-pending}, it can use it however it wishes to (e.g., either a non-tail-recursive continuation, or a tail-recursive accumulator).
+
+@subsection{The Return Continuation, @code{k-return}}
+
+The return continuation is defined by any @emph{transformer} wishing to yield multiple times. It "bookmarks" a point in the stream to return to and continue forward from, forming an epicycle within the containing stream cycle that accumulates "pending output." This dynamic is the reason the approach is referred to as "Pac-Man streams," as it is reminiscent of Pac-Man moving past the edge of the screen on the right and emerging from somewhere on the left while continuing to consume values, in the classic arcade game.
+
+@itemlist[
+  @item{It is initialized to @code{#false} in the @emph{producer}, as there is as yet no return point.}
+  @item{It may be set by any @emph{transformer}.}
+  @item{There, it looks like @code{(λ (k-pending) ... next steps ...)}.}
+  @item{The @emph{consumer} calls it with @code{k-pending} (defined in the consumer) as the only argument.}
+  @item{If there are multiple return points logged, they are handled in a natural way described below under "transformer."}
+]
+
+@subsubsection[#:tag "return:ntrc"]{Non-tail-recursive Consumer}
+
+@itemlist[
+  @item{Recurrence @emph{suspends} calling @code{k-pending} (which begins the next stream cycle) until all yields in the current stream cycle have been accounted for.}
+  @item{At that point, @code{k-pending} is invoked in the consumer's driver loop, which proceeds to the next stream cycle.}
+  @item{This resembles, e.g., @code{(cons v (cons v ... (k-pending)))}.}
+]
+
+@subsubsection[#:tag "return:trc"]{Tail-recursive Consumer}
+
+@itemlist[
+  @item{Recurrence builds @code{k-pending} as an already-reduced intermediate result directly, until all yields in the current stream cycle have been accounted for.}
+  @item{At that point, the consumer's driver loop recurs to the next stream cycle, passing forward @code{k-pending} as the accumulated result.}
+  @item{This resembles, e.g., @code{(go vs k-pending)}.}
+]
+
+@subsection{Virtual Length of the Stream}
+
+Together, these two continuations "virtually" extend the stream, unrolling recurrence into a longer stream from the perspective of the values flowing through it. If each stream segment @code{i} yields @code{kᵢ} values, then a stream of length @code{N} appears to be of virtual length bounded above by @code{N × k₁ × k₂ × ... × kn}.
+
+@section{Stages of Processing}
+
+@subsection{In the Producer}
+
+@itemlist[
+  @item{Its job is simply to determine how to produce individual values from some initial sequence specification (e.g., simply a list, or a set of numbers defining a range, or a vector, etc.). For example, in producing values from a list, it simply yields the @code{car} and @code{cdr}, if it is not @code{null} (in which case it calls @code{done} to terminate).}
+  @item{Only the producer can "unpack" the stream state. Other segments only forward the state on, and can request to "skip" to the next state, a request which the consumer fulfills by passing that next state back to the producer. But only the producer can analyze the state.}
+  @item{It @emph{must} initialize @code{k-return} to @code{#false}, since there is no bookmarked return point yet as we are just starting to process the newly produced value.}
+  @item{It @emph{must} initialize @code{k-pending} to @code{#false}, since this is the pending @emph{output} continuation, which the producer cannot determine (only the consumer can).}
+]
+
+@subsection{In the Transformer}
+
+If it's yielding a single value:
+
+@itemlist[
+  @item{It simply passes forward the pending output and return continuation, unchanged.}
+  @item{The remaining stream state is also passed forward unchanged, as always.}
+  @item{In addition to its own work on the current stream value.}
+]
+
+If it wants to yield multiple values:
+
+@itemlist[
+  @item{It reifies the continuation at that point.}
+  @item{It yields subsequent values within the scope of the newly defined return continuation.}
+  @item{It yields the next value (and untouched remaining stream state).}
+  @item{It passes forward the pending output continuation along with the @emph{newly defined} return continuation.}
+  @item{A return continuation so defined must accept a pending output continuation as argument (which will be supplied when invoked by the @emph{consumer}).}
+  @item{In yielding the final value, it passes forward the @emph{a priori} return continuation.}
+  @item{In this way, the return continuations form a "stack" — later ones shadow earlier ones as long as they are still yielding, and then they convey the a priori one forward at that stage.}
+]
+
+@subsection{In the Consumer}
+
+The consumer is the only one with stream-scoped state (every other segment is fully "Markov" to a specific produced value, and may maintain internal state, e.g., @code{take}).
+
+When a value is received on the @code{yield} continuation:
+
+@itemlist[
+  @item{At this point, we want to incorporate the current value into the result and recur to the next stream cycle, e.g., @code{(cons v (go vs))} or @code{(go vs (cons v result))} (depending on non-tail vs tail-recursive).}
+  @item{And that's what we'll do if no one says otherwise.}
+  @item{But if we see that there is a logged return point (i.e., if @code{k-return} is not @code{#false}), then we add the intended operation to the end of the pending output continuation, instead.}
+  @item{And then return to the point where the work in the current stream state may be continued, passing in the pending output, thus beginning an epicycle within the containing stream cycle.}
+  @item{Finally, if there is no return point but there is pending output, then evaluate it and recur to the next stream state and cycle.}
+]
+
+When a value is received on the @code{skip} continuation,
+
+@itemlist[
+  @item{We'd like to recur to the next stream cycle, e.g., @code{(go vs)} or @code{(go vs result)}.}
+  @item{But if there is a @code{k-return}, we pass, e.g., @code{(λ () (go vs))}, as @code{k-pending} to @code{k-return}, as there may still be more values produced in the current stream cycle, i.e., from the current stream state.}
+  @item{Finally, if there is no return point but there is pending output, then evaluate it and recur to the next stream cycle.}
+]
+
+When the @code{done} continuation is invoked,
+
+@itemlist[
+  @item{If there is pending output in @code{k-pending}, evaluate it. Then, terminate.}
+]
+
+@section{Extension to Buffered Streams}
+
+As we have seen, the scheme elaborated thus far is capable of expressing streams that yield zero or more values in each cycle. But it is necessary that each stream segment make this determination immediately upon receiving each individual value. However, there are cases where a segment --- specifically a transformer --- may prefer to yield values only after seeing several input values, rather than immediately. We refer to this as a case of a "buffered" transformer. The defining property of such a buffered transformer is that it may continue to yield values @emph{even after the producer has determined that the stream is exhausted}.
+
+The key in handling this case, therefore, is for the buffered transformer to assume the role of the producer when this happens, taking on its responsibilities. In particular, in its @code{done} continuation:
+
+@itemlist[
+  @item{It @emph{must} define a return continuation so that the consumer returns control to it at the end of the cycle instead of back to the producer (whose role is concluded).}
+  @item{Instead of passing forward a remaining stream state for the next cycle (which is unavailable as the producer has already determined stream exhaustion), it simply passes forward an unused sentinel value such as @code{#false}.}
+  @item{It must ultimately call the received @code{done} continuation, assuming this responsibility from the producer.}
+]
+
+@section{Reference Code}
+
+The code block below contains a runnable end-to-end stream, minimally and faithfully illustrating the approach described by this document.
+
+@code{producer} produces a stream from a list.
+
+@code{dup-transformer} is a transformer that duplicates each input value, yielding two values for each (thus serving to illustrate a multi-valued transformer).
+
+@code{pair-transformer} is a @emph{buffered} transformer that groups values into pairs, yielding a single list value for every two input values (thus serving to illustrate "buffered" streams). For an odd number of input values, the last value yields a singleton list.
+
+@code{rconsumer} is a non-tail-recursive consumer (like @code{foldr}) that simply constructs a list from the stream.
+
+@code{lconsumer} is a tail-recursive consumer (like @code{foldl}) that simply constructs a list from the stream.
+
+@codeblock{
+  (define producer
+    (λ (done skip yield)
+      (λ (vs)
+        (if (null? vs)
+            (done #false)
+            (let ([v (car vs)]
+                  [vs (cdr vs)])
+              (yield v
+                     vs
+                     #false
+                     #false))))))
+
+  (define (dup-transformer previous)
+    (λ (done skip yield)
+      (previous done
+                skip
+                (λ (v vs k-pending k-return)
+                  (yield v
+                         vs
+                         k-pending
+                         (λ (k-pending)
+                           (yield v
+                                  vs
+                                  k-pending
+                                  k-return)))))))
+
+  (define (pair-transformer previous)
+    (let ([buffer #false])
+      (λ (done skip yield)
+        (previous (λ (k-pending)
+                    (if buffer
+                        (yield (list buffer)
+                               #false
+                               k-pending
+                               (λ (k-pending)
+                                 (done k-pending)))
+                        (done k-pending)))
+                  skip
+                  (λ (v vs k-pending k-return)
+                    (if buffer
+                        (let ([buffered-v buffer])
+                          (set! buffer #false)
+                          (yield (list buffered-v v)
+                                 vs
+                                 k-pending
+                                 k-return))
+                        (begin
+                          (set! buffer v)
+                          (skip vs
+                                k-pending
+                                k-return))))))))
+
+  (define (rconsumer init previous)
+    (λ (vs)
+      (let go ([vs vs])
+        ((previous (λ (k-pending)
+                     (let ([k-pending (or k-pending (λ () init))])
+                       (k-pending)))
+                   (λ (vs k-pending k-return)
+                     (let ([k-pending (or k-pending (if vs
+                                                        (λ () (go vs))
+                                                        (λ () init)))])
+                       (if k-return
+                           (k-return k-pending)
+                           (k-pending))))
+                   (λ (v vs k-pending k-return)
+                     (let ([k-pending (or k-pending (if vs
+                                                        (λ () (go vs))
+                                                        (λ () init)))])
+                       (cons v (if k-return
+                                   (k-return k-pending)
+                                   (k-pending))))))
+         vs))))
+
+  (define (lconsumer init previous)
+    (λ (vs)
+      (let go ([vs vs] [result init])
+        ((previous (λ (k-pending)
+                     (let ([k-pending (or k-pending result)])
+                       k-pending))
+                   (λ (vs k-pending k-return)
+                     (let ([k-pending (or k-pending result)])
+                       (if k-return
+                           (k-return k-pending)
+                           (go vs k-pending))))
+                   (λ (v vs k-pending k-return)
+                     (let* ([k-pending (or k-pending result)]
+                            [k-pending (cons v k-pending)])
+                       (if k-return
+                           (k-return k-pending)
+                           (go vs k-pending)))))
+         vs))))
+
+  ((rconsumer null (dup-transformer producer)) (list 1 2 3))  ;=> '(1 1 2 2 3 3)
+
+  ((lconsumer null (dup-transformer producer)) (list 1 2 3))  ;=> '(3 3 2 2 1 1)
+
+  ((rconsumer null (pair-transformer producer)) (list 1 2 3))  ;=> '((1 2) (3))
+
+}
+
+@section{Summary}
+
+We described in detail Qi's continuation-passing stream fusion implementation, including a natural generalization to support multiple values while preserving the performance characteristics of the single-valued implementation. This covered the stream's construction as a nest of closures; the use of @code{done}, @code{skip} and @code{yield} continuations to implement each cycle of the stream's semantics; the addition of @code{k-pending} and @code{k-return} continuations introducing "epicycles" within a cycle to support multiple yields; the distinct roles and responsibilities of the producer, each transformer, and the consumer, and how these responsibilities shift to accommodate "buffered" transformers that yield output only after considering several input values; the subtle distinction between tail-recursive and non-tail-recursive consumers and implications for performance; and finally, a minute analysis of the stream's ultimate application to arguments and its evaluation to a result.
+
+@(bibliography
+
+  (bib-entry #:key "St-Amour12"
+             #:author "Vincent St-Amour"
+             #:title "Deforestation"
+             #:date "2012"
+             #:url "https://www.ccs.neu.edu/home/amal/course/7480-s12/deforestation-notes.pdf")
+
+  (bib-entry #:key "Steele77"
+             #:author "Guy Lewis Steele Jr."
+             #:title "LAMBDA: The Ultimate GOTO"
+             #:date "1977"
+             #:url "https://www2.cs.sfu.ca/CourseCentral/383/havens/pubs/lambda-the-ultimate-goto.pdf")
+
+)


### PR DESCRIPTION
### Summary of Changes

Start a new `design` folder to keep track of designs considered. Also add a makefile target to build design documents.

The output of these design documents may be seen here:

[Virtual Multi-valued Streams (Pac-Man)](https://countvajhula.com/oldsite/qi/pacman/)
[Language Composition](https://countvajhula.com/oldsite/qi/langcomp) [archived]

I'm still working on the design document for core streams, but I'll aim to put that in a separate PR as there is still a lot of work to be done there, including work on the actual POC, which we can eventually commit here and track in the `design/` folder.

This process of tracking designs follows the one used in the Rhombus project (which I helped to put in place).

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
