### PR TITLE
Simplify pacman design

### DIFF
--- a/design/language-composition/language-composition.scrbl
+++ b/design/language-composition/language-composition.scrbl
@@ -6,7 +6,7 @@
 
 @title{Language Extension Through Inheritance and Composition}
 
-@centered{@bold{@tt{Technical Specification}}}
+@centered{@bold{@tt{Qi Improvement Proposal (QIP)}}}
 @centered{@bold{@tt{Status: @elem[#:style "status-archived"]{@tt{ARCHIVED}}}}}
 
 @abstract{We look at a few different ways of extending a hosted language implemented in Syntax Spec. We describe a means of extension that affords the same flexibility to hosted languages that Syntax Spec already brings to the host language, that is, holistic and sound syntactic and runtime extensibility.}

--- a/design/pacman-streams/pacman.scrbl
+++ b/design/pacman-streams/pacman.scrbl
@@ -6,7 +6,7 @@
 
 @title{Virtual Multi-valued Streams @(linebreak) or, "Pac-Man Continuations" @(linebreak)}
 
-@centered{@bold{@tt{Technical Specification}}}
+@centered{@bold{@tt{Qi Improvement Proposal (QIP)}}}
 @centered{@bold{@tt{Status: @elem[#:style "status-accepted"]{@tt{ACCEPTED}}}}}
 
 @abstract{


### PR DESCRIPTION
### Summary of Changes

- Dramatically simplify the design of Pac-Man streams (commit message explains)
- Call these design documents "Qi Improvement Proposals" or "QIPs" (pronounced "chips") 😄 
- Add the standalone proof-of-concept (POC) code to accompany the design

The [rendered HTML](https://countvajhula.com/oldsite/qi/pacman/).

Formerly this design felt clever and elegant. Now it feels simple and almost obvious. Simplicity is the surest sign of a good design!

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
